### PR TITLE
Add entry count information to dictionary metadata

### DIFF
--- a/elexis.json
+++ b/elexis.json
@@ -729,6 +729,10 @@
                             "name": "Publishing Company"
                         }]
                     },
+	            "entryCount": {
+                        "description": "Number of entries in the dictionary.",
+                        "type": "integer"
+                    },
 	            "abstract": {
                         "description": "A summary of the resource.",
                         "type": "string"


### PR DESCRIPTION
Add entry count as an optional metadata property of dictionary.